### PR TITLE
Refactor strainRateTensor calculation for physical units

### DIFF
--- a/src/functionObjects/strainRateTensor.cuh
+++ b/src/functionObjects/strainRateTensor.cuh
@@ -78,21 +78,14 @@ namespace LBM
             {
                 static_assert((Index == index::xx || Index == index::yy || Index == index::zz || Index == index::xy || Index == index::xz || Index == index::yz), "Invalid index");
                 
-                const scalar_t uA_phys = uAlpha / velocitySetBase::scale_i<scalar_t>();
-                const scalar_t uB_phys = uBeta  / velocitySetBase::scale_i<scalar_t>();
-
-                if constexpr (Index == index::xx || Index == index::yy || Index == index::zz)
+                if constexpr (Index == index::xx || Index == index::yy || Index == index::zz)  
                 {
-                    const scalar_t m_phys = mAlphaBeta / velocitySetBase::scale_ii<scalar_t>();
-
-                    return velocitySetBase::as2<scalar_t>() * ((uA_phys * uB_phys) - m_phys) / (static_cast<scalar_t>(2) * device::tau);
-                }
-                else
-                {
-                    const scalar_t m_phys = mAlphaBeta / velocitySetBase::scale_ij<scalar_t>();;
-
-                    return velocitySetBase::as2<scalar_t>() * ((uA_phys * uB_phys) - m_phys) / (static_cast<scalar_t>(2) * device::tau);
+                    velocitySetBase::scale_ii<scalar_t>() * ((uAlpha * uBeta) - mAlphaBeta) / device::tau;  
                 }  
+                else  
+                {  
+                    velocitySetBase::scale_ij<scalar_t>() * ((uAlpha * uBeta) - mAlphaBeta) / device::tau;  
+                }
             }
 
             /**

--- a/src/functionObjects/strainRateTensor.cuh
+++ b/src/functionObjects/strainRateTensor.cuh
@@ -77,15 +77,22 @@ namespace LBM
             __device__ [[nodiscard]] static inline constexpr scalar_t calculate(const scalar_t uAlpha, const scalar_t uBeta, const scalar_t mAlphaBeta) noexcept
             {
                 static_assert((Index == index::xx || Index == index::yy || Index == index::zz || Index == index::xy || Index == index::xz || Index == index::yz), "Invalid index");
+                
+                const scalar_t uA_phys = uAlpha / velocitySetBase::scale_i<scalar_t>();
+                const scalar_t uB_phys = uBeta  / velocitySetBase::scale_i<scalar_t>();
 
                 if constexpr (Index == index::xx || Index == index::yy || Index == index::zz)
                 {
-                    return velocitySetBase::as2<scalar_t>() * ((uAlpha * uBeta) - mAlphaBeta) / (static_cast<scalar_t>(2) * velocitySetBase::scale_ii<scalar_t>() * device::tau);
+                    const scalar_t m_phys = mAlphaBeta / velocitySetBase::scale_ii<scalar_t>();
+
+                    return velocitySetBase::as2<scalar_t>() * ((uA_phys * uB_phys) - m_phys) / (static_cast<scalar_t>(2) * device::tau);
                 }
                 else
                 {
-                    return velocitySetBase::as2<scalar_t>() * ((uAlpha * uBeta) - mAlphaBeta) / (static_cast<scalar_t>(2) * velocitySetBase::scale_ij<scalar_t>() * device::tau);
-                }
+                    const scalar_t m_phys = mAlphaBeta / velocitySetBase::scale_ij<scalar_t>();;
+
+                    return velocitySetBase::as2<scalar_t>() * ((uA_phys * uB_phys) - m_phys) / (static_cast<scalar_t>(2) * device::tau);
+                }  
             }
 
             /**


### PR DESCRIPTION
I'm still getting used to the moment representation of LBM, as I have never properly studied its implementation before, so this is more of a question than a correction!

I believe that the equilibrium contribution to the strain-rate tensor should be zero. Substituting

$$
\hat{m}_{ii}^{\text{eq}} = \hat{u}_i^2 / 2
$$

into the diagonal part of $S_{ii}$,

$$
S_{ii}^{\text{eq}} = \frac{a_s^2}{2\tau}\frac{\hat{u}_i^2 - \hat{m}_{ii}}{s_{ii}} = \frac{a_s^2}{2 \tau} \frac{\hat{u}_i^2 / 2}{s_{ii}},
$$

and substituting all the scaling factors, I obtain

$$
S_{ii}^{\text{eq}} = \frac{3}{2} \frac{u^2}{\tau} \neq 0.
$$

The solution, as I understand it, is to scale all moments and velocities to physical units before performing the computations. This doesnt happen in the diagonal components of Sij.